### PR TITLE
fix(service_message): fix empty message field name

### DIFF
--- a/srv/ElevatorStatusSrv.srv
+++ b/srv/ElevatorStatusSrv.srv
@@ -1,4 +1,4 @@
-std_msgs/Empty
+std_msgs/Empty empty
 ---
 std_msgs/Header header
 


### PR DESCRIPTION
Related Issues:
https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs/issues/10

Related PRs:
https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs/pull/9

Fix the empty field name of the empty message in service.