### PR TITLE
Update ElevatorStatusSrv.srv

### DIFF
--- a/srv/ElevatorStatusSrv.srv
+++ b/srv/ElevatorStatusSrv.srv
@@ -1,4 +1,3 @@
-std_msgs/Empty
 ---
 std_msgs/Header header
 


### PR DESCRIPTION
일부 빌드 환경에서 오류 발생하는 경우가 있어
std_msgs/Empty -> 공백으로 변경